### PR TITLE
Make all listeners non-passive

### DIFF
--- a/src/drag.js
+++ b/src/drag.js
@@ -51,7 +51,9 @@ export default function() {
     if (touchending || !filter.apply(this, arguments)) return;
     var gesture = beforestart("mouse", container.apply(this, arguments), mouse, this, arguments);
     if (!gesture) return;
-    select(event.view).on("mousemove.drag", mousemoved, true).on("mouseup.drag", mouseupped, true);
+    select(event.view)
+      .on("mousemove.drag", mousemoved, {capture: true, passive: false})
+      .on("mouseup.drag", mouseupped, {capture: true, passive: false});
     nodrag(event.view);
     nopropagation();
     mousemoving = false;


### PR DESCRIPTION
Listeners are *non*-passive by default. But it is possible to use something like https://github.com/zzarcon/default-passive-events to make listeners passive by default. In this case one must be explicit with where one wants *non*-passive listeners.

Fixes: https://github.com/d3/d3-drag/issues/51