### PR TITLE
Conditionally allow propagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This table describes how the drag behavior interprets native events:
 | touchend     | selection         | end        | no⁴                |
 | touchcancel  | selection         | end        | no⁴                |
 
-The propagation of all consumed events is [immediately stopped](https://dom.spec.whatwg.org/#dom-event-stopimmediatepropagation). If you want to prevent some events from initiating a drag gesture, use [*drag*.filter](#drag_filter).
+The propagation of all consumed events is [immediately stopped](https://dom.spec.whatwg.org/#dom-event-stopimmediatepropagation). If you want to prevent some events from initiating a drag gesture, use [*drag*.filter](#drag_filter). If you want to allow events to propagate, use [*drag*.allowPropagation](#drag_allowPropagation).
 
 ¹ Necessary to capture events outside an iframe; see [#9](https://github.com/d3/d3-drag/issues/9).
 <br>² Only applies during an active, mouse-based gesture; see [#9](https://github.com/d3/d3-drag/issues/9).
@@ -194,6 +194,10 @@ Prevents native drag-and-drop and text selection on the specified *window*. As a
 <a href="#dragEnable" name="dragEnable">#</a> d3.<b>dragEnable</b>(<i>window</i>[, <i>noclick</i>]) [<>](https://github.com/d3/d3-drag/blob/master/src/nodrag.js#L15 "Source")
 
 Allows native drag-and-drop and text selection on the specified *window*; undoes the effect of [d3.dragDisable](#dragDisable). This method is intended to be called on mouseup, preceded by [d3.dragDisable](#dragDisable) on mousedown. If *noclick* is true, this method also temporarily suppresses click events. The suppression of click events expires after a zero-millisecond timeout, such that it only suppress the click event that would immediately follow the current mouseup event, if any.
+
+<a href="#allowPropagation" name="allowPropagation">#</a> d3.<b>allowPropagation</b>([<i>allowPropagation</i>]) [<>](https://github.com/d3/d3-drag/blob/master/src/nodrag.js#L167 "Source")
+
+If *allowPropagation* is specified, sets the specified propagation setting and returns the drag behavior. If *allowPropagation* is not specified, returns the current propagation setting, which defaults to: *false*.
 
 ### Drag Events
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This table describes how the drag behavior interprets native events:
 | touchend     | selection         | end        | no⁴                |
 | touchcancel  | selection         | end        | no⁴                |
 
-The propagation of all consumed events is [immediately stopped](https://dom.spec.whatwg.org/#dom-event-stopimmediatepropagation). If you want to prevent some events from initiating a drag gesture, use [*drag*.filter](#drag_filter). If you want to allow events to propagate, use [*drag*.allowPropagation](#drag_allowPropagation).
+The propagation of all consumed events is [immediately stopped](https://dom.spec.whatwg.org/#dom-event-stopimmediatepropagation). If you want to prevent some events from initiating a drag gesture, use [*drag*.filter](#drag_filter). If you want to allow events to propagate, use [*drag*.allowPropagation](#allowPropagation).
 
 ¹ Necessary to capture events outside an iframe; see [#9](https://github.com/d3/d3-drag/issues/9).
 <br>² Only applies during an active, mouse-based gesture; see [#9](https://github.com/d3/d3-drag/issues/9).
@@ -195,7 +195,7 @@ Prevents native drag-and-drop and text selection on the specified *window*. As a
 
 Allows native drag-and-drop and text selection on the specified *window*; undoes the effect of [d3.dragDisable](#dragDisable). This method is intended to be called on mouseup, preceded by [d3.dragDisable](#dragDisable) on mousedown. If *noclick* is true, this method also temporarily suppresses click events. The suppression of click events expires after a zero-millisecond timeout, such that it only suppress the click event that would immediately follow the current mouseup event, if any.
 
-<a href="#allowPropagation" name="allowPropagation">#</a> d3.<b>allowPropagation</b>([<i>allowPropagation</i>]) [<>](https://github.com/d3/d3-drag/blob/master/src/nodrag.js#L167 "Source")
+<a href="#allowPropagation" name="allowPropagation">#</a> d3.<b>allowPropagation</b>([<i>allowPropagation</i>]) [<>](https://github.com/d3/d3-drag/blob/master/src/drag.js#L167 "Source")
 
 If *allowPropagation* is specified, sets the specified propagation setting and returns the drag behavior. If *allowPropagation* is not specified, returns the current propagation setting, which defaults to: *false*.
 

--- a/src/drag.js
+++ b/src/drag.js
@@ -34,7 +34,7 @@ export default function() {
       mousedowny,
       mousemoving,
       touchending,
-      clickDistance2 = 0
+      clickDistance2 = 0,
       allowPropagation = false;
 
   function drag(selection) {

--- a/src/drag.js
+++ b/src/drag.js
@@ -34,7 +34,8 @@ export default function() {
       mousedowny,
       mousemoving,
       touchending,
-      clickDistance2 = 0;
+      clickDistance2 = 0
+      allowPropagation = false;
 
   function drag(selection) {
     selection
@@ -53,7 +54,7 @@ export default function() {
     if (!gesture) return;
     select(event.view).on("mousemove.drag", mousemoved, true).on("mouseup.drag", mouseupped, true);
     nodrag(event.view);
-    nopropagation();
+    nopropagation(allowPropagation);
     mousemoving = false;
     mousedownx = event.clientX;
     mousedowny = event.clientY;
@@ -61,7 +62,7 @@ export default function() {
   }
 
   function mousemoved() {
-    noevent();
+    noevent(allowPropagation);
     if (!mousemoving) {
       var dx = event.clientX - mousedownx, dy = event.clientY - mousedowny;
       mousemoving = dx * dx + dy * dy > clickDistance2;
@@ -72,7 +73,7 @@ export default function() {
   function mouseupped() {
     select(event.view).on("mousemove.drag mouseup.drag", null);
     yesdrag(event.view, mousemoving);
-    noevent();
+    noevent(allowPropagation);
     gestures.mouse("end");
   }
 
@@ -84,7 +85,7 @@ export default function() {
 
     for (i = 0; i < n; ++i) {
       if (gesture = beforestart(touches[i].identifier, c, touch, this, arguments)) {
-        nopropagation();
+        nopropagation(allowPropagation);
         gesture("start");
       }
     }
@@ -96,7 +97,7 @@ export default function() {
 
     for (i = 0; i < n; ++i) {
       if (gesture = gestures[touches[i].identifier]) {
-        noevent();
+        noevent(allowPropagation);
         gesture("drag");
       }
     }
@@ -110,7 +111,7 @@ export default function() {
     touchending = setTimeout(function() { touchending = null; }, 500); // Ghost clicks are delayed!
     for (i = 0; i < n; ++i) {
       if (gesture = gestures[touches[i].identifier]) {
-        nopropagation();
+        nopropagation(allowPropagation);
         gesture("end");
       }
     }
@@ -161,6 +162,10 @@ export default function() {
 
   drag.clickDistance = function(_) {
     return arguments.length ? (clickDistance2 = (_ = +_) * _, drag) : Math.sqrt(clickDistance2);
+  };
+
+  drag.allowPropagation = function(_) {
+    return arguments.length ? (allowPropagation = typeof _ === "function" ? _ : constant(!!_), drag) : allowPropagation;
   };
 
   return drag;

--- a/src/noevent.js
+++ b/src/noevent.js
@@ -1,10 +1,10 @@
 import {event} from "d3-selection";
 
-export function nopropagation() {
-  event.stopImmediatePropagation();
+export function nopropagation(allowPropagation) {
+  !allowPropagation && event.stopImmediatePropagation();
 }
 
-export default function() {
+export default function(allowPropagation) {
   event.preventDefault();
-  event.stopImmediatePropagation();
+  !allowPropagation && event.stopImmediatePropagation();
 }


### PR DESCRIPTION
I have a use case where it is useful to be able to consume the events that propagate from `d3.drag()`.  It involves using a drag behavior to add panning to the y axis of a chart, while using `d3.zoom()` to translate and scale the x axis of the chart.  Let me know if you want to see a demo.  Thanks! 