### PR TITLE
drag().on("init")

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ The *typenames* is a string containing one or more *typename* separated by white
 * `start` - after a new pointer becomes active (on mousedown or touchstart).
 * `drag` - after an active pointer moves (on mousemove or touchmove).
 * `end` - after an active pointer becomes inactive (on mouseup, touchend or touchcancel).
+* `init` - when the drag behavior is applied.
 
 See [*dispatch*.on](https://github.com/d3/d3-dispatch#dispatch_on) for more.
 

--- a/src/drag.js
+++ b/src/drag.js
@@ -28,7 +28,7 @@ export default function() {
       subject = defaultSubject,
       touchable = defaultTouchable,
       gestures = {},
-      listeners = dispatch("start", "drag", "end"),
+      listeners = dispatch("start", "drag", "end", "init"),
       active = 0,
       mousedownx,
       mousedowny,
@@ -45,6 +45,13 @@ export default function() {
         .on("touchend.drag touchcancel.drag", touchended)
         .style("touch-action", "none")
         .style("-webkit-tap-highlight-color", "rgba(0,0,0,0)");
+    selection.each(function(d) {
+      var that = this;
+      listeners.call("init", that,
+        new DragEvent("init", { target: drag, dispatch: listeners }),
+        d
+      );
+    });
   }
 
   function mousedowned(event, d) {


### PR DESCRIPTION
fixes https://github.com/d3/d3-drag/issues/67

"init" is dispatched after the initial setup, so we can "undo" the styles etc.